### PR TITLE
don't execute empty command

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -113,6 +113,7 @@ function now()
 end
 
 function command(command)
+    if not command or command == '' then return true end
     return mp.command(command)
 end
 
@@ -238,7 +239,7 @@ function InputEvent:emit(event)
         mp.msg.warn("Unsafe property-expansion: " .. cmd)
     end
 
-    if cmd ~= '' then command(cmd) end
+    command(cmd)
 end
 
 function InputEvent:handler(event)

--- a/inputevent.lua
+++ b/inputevent.lua
@@ -238,7 +238,7 @@ function InputEvent:emit(event)
         mp.msg.warn("Unsafe property-expansion: " .. cmd)
     end
 
-    command(cmd)
+    if cmd ~= '' then command(cmd) end
 end
 
 function InputEvent:handler(event)


### PR DESCRIPTION
使用 Property Expansion 语法的时候，解析出来命令可能为空，执行空命令控制台会有报错。
![屏幕截图 2024-05-12 150921](https://github.com/natural-harmonia-gropius/input-event/assets/45035465/0f7e5209-294e-45c6-ba4c-708fd4ee6d4d)

比如这种需求，在idle界面时左键不触发切换暂停，命令是空的干脆不执行，避免控制台报错。
```json
[
  {
    "key": "MBTN_LEFT",
    "on": {
      "click": "${?idle-active==no:cycle pause}",
      "double_click": "cycle fullscreen"
    }
  }
]
```
