### PR TITLE
Support for string array command syntax in JSON configuration file

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -227,6 +227,10 @@ function InputEvent:emit(event)
         event = "click"
     end
 
+    if type(self.on[event]) == "table" then
+        self.on[event] = table.concat(self.on[event], " ")
+    end
+
     local cmd = self.on[event]
     if not cmd or cmd == "" then
         return


### PR DESCRIPTION
JSON配置中支持一种命令的新语法，不影响原有语法。

主要是有些命令太长了，例如`script-message-to`和`change-list`等，有时候还要连续几个命令写在一起，写成数组的形式就可以随意换行了。

```json
[
  {
    "key": "F2",
    "on": {
      "click": ["change-list glsl-shaders clr '';", 
        "change-list glsl-shaders append",
        "'~~/shaders/Anime4K_Darken_HQ.glsl';",
        "change-list glsl-shaders append",
        "'~~/shaders/Anime4K_Thin_HQ.glsl';",
        "...", "..."
      ]
    }
  }
]
```