### PR TITLE
prevent conflicts with other menu plugins

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -353,6 +353,14 @@ function unbind(key)
         bind_map[key] = nil
     end
 end
+function is_bindable_event(event_name)
+	for _, event in ipairs(event_pattern) do
+		if event.to==event_name then
+			return true
+		end	
+	end	
+	return false
+end
 
 function bind_from_conf(conf)
     local kv = {}
@@ -365,7 +373,8 @@ function bind_from_conf(conf)
                 local events = table.filter(comments, function(i, v) return v:match("^@") end)
                 if events and #events > 0 then
                     local event = events[1]:match("^@(.*)"):trim()
-                    if event and event ~= "" then
+                    if event and is_bindable_event(event) then
+						print("event="..event)
                         if kv[key] == nil then
                             kv[key] = {}
                         end

--- a/inputevent.lua
+++ b/inputevent.lua
@@ -359,7 +359,7 @@ function is_bindable_event(event_name)
 			return true
 		end	
 	end	
-	return false
+	return event_name=="repeat"
 end
 
 function bind_from_conf(conf)


### PR DESCRIPTION
When using [mpv-menu-plugin](https://github.com/tsl0922/mpv-menu-plugin) I noticed that keys that had a @state property weren't working. 

This allows input-event to co-exist with other menu plugins by only binding events that match supported "to" types