### PR TITLE
Add option.prefix

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -6,6 +6,7 @@ local options = require("mp.options")
 
 local o = {
     configs = "input.conf",
+    prefix = "@"
 }
 
 local bind_map = {}
@@ -362,9 +363,9 @@ function bind_from_conf(conf)
             local key, cmd, comment = line:match("%s*([%S]+)%s+(.-)%s+#%s*(.-)%s*$")
             if comment then
                 local comments = comment:split("#")
-                local events = table.filter(comments, function(i, v) return v:match("^@") end)
+                local events = table.filter(comments, function(i, v) return v:match("^" .. o.prefix) end)
                 if events and #events > 0 then
-                    local event = events[1]:match("^@(.*)"):trim()
+                    local event = events[1]:match("^" .. o.prefix .. "(.*)"):trim()
                     if event and event ~= "" then
                         if kv[key] == nil then
                             kv[key] = {}


### PR DESCRIPTION
Very direct and simple solution, no extra costs. alt to https://github.com/natural-harmonia-gropius/input-event/pull/46 and https://github.com/natural-harmonia-gropius/input-event/pull/47.

mpv.conf

```
script-opts-append=inputevent-prefix=event:
```

input.conf

```
MBTN_LEFT           cycle pause                                                 #event: click
MBTN_LEFT           cycle fullscreen                                            #event: double_click
```

@tylandercasper @Mark-Joy Any advice?