### PR TITLE
Add missed input command prefix

### DIFF
--- a/inputevent.lua
+++ b/inputevent.lua
@@ -29,8 +29,8 @@ for _, value in ipairs(event_pattern) do
 end
 
 -- https://mpv.io/manual/master/#input-command-prefixes
-local prefixes = { "osd-auto", "no-osd", "osd-bar", "osd-msg", "osd-msg-bar", "raw", "expand-properties", "repeatable",
-    "async", "sync" }
+local prefixes = { "osd-auto", "no-osd", "osd-bar", "osd-msg", "osd-msg-bar", "raw", "expand-properties",
+    "repeatable", "nonrepeatable", "async", "sync" }
 
 -- https://mpv.io/manual/master/#list-of-input-commands
 local commands = { "set", "cycle", "add", "multiply" }


### PR DESCRIPTION
`nonrepeatable` was missed